### PR TITLE
Fix docker run failure after refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ format:
 build: promu
 	@echo ">> building binaries"
 	@$(PROMU) build --prefix $(PREFIX)
-	@mv  ./vertica-prometheus-exporter ./cmd/vertica_promethues_exporter
+	@mv  ./vertica-prometheus-exporter ./cmd/vertica_prometheus_exporter/vertica-prometheus-exporter
 	
 
 promu:


### PR DESCRIPTION
After the rename, the workflows failed as the Makefile didn't have the write binary path.