### PR TITLE
Change workflow to pull latest vertica-ce image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
       timeout-minutes: 15
       run: |
           docker network create -d bridge vertica
-          docker pull vertica/vertica-ce:12.0.0-0
+          docker pull vertica/vertica-ce:latest
           docker run -d -p 5433:5433 -p 5444:5444 \
             -itd --network=vertica \
             --name vertica_docker \
@@ -47,7 +47,7 @@ jobs:
       timeout-minutes: 15
       run: |
           docker build . -t vertica-prometheus-exporter
-          docker run -d -i -p 9968:9968 -itd --network=vertica  --name vertica-prometheus-exporter vertica-prometheus-exporter:latest
+          docker run -d -i -p 9968:9968 -itd --network=vertica --name vertica-prometheus-exporter vertica-prometheus-exporter:latest
           docker logs vertica-prometheus-exporter 
           echo "Vertica exporter started successfully..."
           docker ps

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Get Prometheus vertica prometheus exporter, either as a packaged release, as a D
 
 
 ```shell
-$ go install github.com/vertica/vertica-prometheus-exporter@latest
+$ go install github.com/vertica/vertica-prometheus-exporter/cmd/vertica_prometheus_exporter@latest
 ```
 then run it from the command line, given ~/go/bin is in your PATH:
 ```shell


### PR DESCRIPTION
- Changed the workflow file to only use the latest vertica-ce image. We were downloading vertica-ce:12.0.0-0 was not necessary.
- Fixed the README with correct go install command